### PR TITLE
Feat/#16 diary content api

### DIFF
--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/Diary.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/Diary.java
@@ -1,6 +1,7 @@
 package org.kau.kkoolbeeServer.domain.diary;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import org.kau.kkoolbeeServer.domain.advice.Advice;
 import org.kau.kkoolbeeServer.domain.member.Member;
 import org.kau.kkoolbeeServer.global.common.domain.BaseTimeEntity;
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
+@Getter
 public class Diary extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
@@ -1,7 +1,11 @@
 package org.kau.kkoolbeeServer.domain.diary.controller;
 
+import org.kau.kkoolbeeServer.domain.diary.request.DiaryContentRequest;
+import org.kau.kkoolbeeServer.domain.diary.response.DiaryContentResponse;
 import org.kau.kkoolbeeServer.domain.diary.service.DiaryService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,5 +17,15 @@ public class DiaryController {
     public DiaryController(DiaryService diaryService) {
         this.diaryService = diaryService;
     }
+
+    public ResponseEntity<?> getDiaryContent(@RequestBody DiaryContentRequest request){
+        Long diaryId=request.getDiaryId();
+
+        DiaryContentResponse response=diaryService.getDiaryContent(diaryId);
+    }
+
+
+
+
 
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
@@ -3,6 +3,7 @@ package org.kau.kkoolbeeServer.domain.diary.controller;
 import org.kau.kkoolbeeServer.domain.diary.request.DiaryContentRequest;
 import org.kau.kkoolbeeServer.domain.diary.response.DiaryContentResponse;
 import org.kau.kkoolbeeServer.domain.diary.service.DiaryService;
+import org.kau.kkoolbeeServer.global.common.dto.enums.SuccessType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,7 +23,12 @@ public class DiaryController {
         Long diaryId=request.getDiaryId();
 
         DiaryContentResponse response=diaryService.getDiaryContent(diaryId);
+
+        return ResponseEntity.status(SuccessType.PROCESS_SUCCESS.getHttpStatusCode())
+                .body(response);
+
     }
+
 
 
 

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
@@ -6,6 +6,7 @@ import org.kau.kkoolbeeServer.domain.diary.service.DiaryService;
 import org.kau.kkoolbeeServer.global.common.dto.enums.SuccessType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +20,7 @@ public class DiaryController {
         this.diaryService = diaryService;
     }
 
+    @PostMapping("/api/diary/content")
     public ResponseEntity<?> getDiaryContent(@RequestBody DiaryContentRequest request){
         Long diaryId=request.getDiaryId();
 

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
@@ -1,0 +1,17 @@
+package org.kau.kkoolbeeServer.domain.diary.controller;
+
+import org.kau.kkoolbeeServer.domain.diary.service.DiaryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DiaryController {
+
+
+    private DiaryService diaryService;
+    @Autowired
+    public DiaryController(DiaryService diaryService) {
+        this.diaryService = diaryService;
+    }
+
+}

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/repository/DiaryRepository.java
@@ -1,0 +1,8 @@
+package org.kau.kkoolbeeServer.domain.diary.repository;
+
+import org.kau.kkoolbeeServer.domain.diary.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryRepository extends JpaRepository<Diary,Long> {
+
+}

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/request/DiaryContentRequest.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/request/DiaryContentRequest.java
@@ -1,0 +1,11 @@
+package org.kau.kkoolbeeServer.domain.diary.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DiaryContentRequest {
+    private Long diaryId;
+
+}

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/response/DiaryContentResponse.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/response/DiaryContentResponse.java
@@ -1,0 +1,16 @@
+package org.kau.kkoolbeeServer.domain.diary.response;
+
+import org.kau.kkoolbeeServer.domain.advice.Advice;
+import org.kau.kkoolbeeServer.domain.diary.Feeling;
+
+import java.util.List;
+
+public class DiaryContentResponse {
+    public class DiaryResponse {
+        private String diaryContent;
+        private Advice advice;
+        private List<Feeling> feelings;
+
+        // 생성자, Getter, Setter 생략
+    }
+}

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/response/DiaryContentResponse.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/response/DiaryContentResponse.java
@@ -1,16 +1,22 @@
 package org.kau.kkoolbeeServer.domain.diary.response;
 
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.kau.kkoolbeeServer.domain.advice.Advice;
 import org.kau.kkoolbeeServer.domain.diary.Feeling;
 
 import java.util.List;
 
+@AllArgsConstructor
 public class DiaryContentResponse {
-    public class DiaryResponse {
+
         private String diaryContent;
-        private Advice advice;
-        private List<Feeling> feelings;
+        private Advice kindAdvice;
+        private Advice spicyAdvice;
+        private Feeling kindFeeling;
+        private Feeling spicyFeeling;
+
 
         // 생성자, Getter, Setter 생략
-    }
+
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
@@ -1,8 +1,15 @@
 package org.kau.kkoolbeeServer.domain.diary.service;
 
+import com.amazonaws.services.kms.model.NotFoundException;
+import org.kau.kkoolbeeServer.domain.advice.Advice;
+import org.kau.kkoolbeeServer.domain.diary.Diary;
+import org.kau.kkoolbeeServer.domain.diary.Feeling;
 import org.kau.kkoolbeeServer.domain.diary.repository.DiaryRepository;
+import org.kau.kkoolbeeServer.domain.diary.response.DiaryContentResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class DiaryService {
@@ -11,5 +18,19 @@ public class DiaryService {
     public DiaryService(DiaryRepository diaryRepository) {
         this.diaryRepository = diaryRepository;
     }
+
+    public DiaryContentResponse getDiaryContent(Long diaryId) {
+        // 일기를 데이터베이스에서 조회
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new NotFoundException("해당 일기를 찾을 수 없습니다."));
+
+        // 응답 데이터 구성
+        String diaryContent = diary.getContent();
+        //List<Feeling> feelings = diary.getSummary(); // 이 부분은 수정해야할 수도 있습니다.
+
+
+        Advice advice = diary.getAdvice();
+
+        return new DiaryContentResponse(diaryContent, feelings, advice);
 
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
@@ -26,7 +26,7 @@ public class DiaryService {
 
         // 응답 데이터 구성
         String diaryContent = diary.getContent();
-        //List<Feeling> feelings = diary.getSummary(); // 이 부분은 수정해야할 수도 있습니다.
+
 
 
         Advice advice = diary.getAdvice();

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
@@ -28,9 +28,12 @@ public class DiaryService {
         String diaryContent = diary.getContent();
 
 
+        Advice kindAdvice = diary.getKindAdvice();
+        Advice spicyAdvice = diary.getSpicyAdvice();
+        Feeling firstFeeling = diary.getFirstFeeling();
+        Feeling secondFeeling = diary.getSecondFeeling();
 
-        Advice advice = diary.getAdvice();
-
-        return new DiaryContentResponse(diaryContent, feelings, advice);
+        return new DiaryContentResponse(diaryContent, kindAdvice, spicyAdvice, firstFeeling, secondFeeling);
+    }
 
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
@@ -20,11 +20,11 @@ public class DiaryService {
     }
 
     public DiaryContentResponse getDiaryContent(Long diaryId) {
-        // 일기를 데이터베이스에서 조회
+
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new NotFoundException("해당 일기를 찾을 수 없습니다."));
 
-        // 응답 데이터 구성
+
         String diaryContent = diary.getContent();
 
 

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
@@ -1,0 +1,15 @@
+package org.kau.kkoolbeeServer.domain.diary.service;
+
+import org.kau.kkoolbeeServer.domain.diary.repository.DiaryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DiaryService {
+    private DiaryRepository diaryRepository;
+    @Autowired
+    public DiaryService(DiaryRepository diaryRepository) {
+        this.diaryRepository = diaryRepository;
+    }
+
+}

--- a/src/main/java/org/kau/kkoolbeeServer/domain/member/controller/MemberController.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/member/controller/MemberController.java
@@ -1,0 +1,14 @@
+package org.kau.kkoolbeeServer.domain.member.controller;
+
+import org.kau.kkoolbeeServer.domain.member.service.MemberService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberController {
+    private MemberService memberService;
+    @Autowired
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+}

--- a/src/main/java/org/kau/kkoolbeeServer/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package org.kau.kkoolbeeServer.domain.member.repository;
+
+import org.kau.kkoolbeeServer.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {
+}

--- a/src/main/java/org/kau/kkoolbeeServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/member/service/MemberService.java
@@ -1,0 +1,14 @@
+package org.kau.kkoolbeeServer.domain.member.service;
+
+import org.kau.kkoolbeeServer.domain.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+    private MemberRepository memberRepository;
+    @Autowired
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+}


### PR DESCRIPTION
## Related Issue 🍫

- close : #[16]

## Summary 🍪

diarycontentApi구현
Member 레포지토리,서비스, 컨트롤러 생성(생성까지만!)

Diary 레포지토리 ,서비스, 컨트롤러 생성

DiaryContentRequest생성 (클라이언트에서 diary_id받아오는)

DiaryContentResponse생성 (클라이언트에게 일기내용, 감정2개, 조언2개 반환하는)

로직에 맞게 Diary 서비스 ,컨트롤러 ,레포지토리 구현

postmapping으로 getDiaryContent메서드생성




## Before i request PR review 🍰

- 코드리뷰로 확인 부탁하는 사항
- 일단 Member가 로그인때문에.. 건들기가 어려워서 (괜히 건들였다가 호은님만 힘들어질까봐 멤버는 컨트롤러 ,서비스,레포지토리 클래스만 생성해놓고)
따로 로직은 작성안했습니다

엄청 쉬운 로직이긴하지만 
설명 드리자면 request로 id받아오고 컨트롤러에서 서비스 호출-> 레포지토리에서 id값으로 해당diary받아와서 서비스에 반환 
-> 서비스에서 만들어놓은 request객체생성( diary에 있는 내용, 감정2개, 조언2개를 가진 객체)  ->
컨트롤러에서 클라이언트에게 request객체를 반환!! 이런 구조로 짜봤습니다!!!


