### PR TITLE
Refactor/#22 entity feeling retouch

### DIFF
--- a/src/main/java/org/kau/kkoolbeeServer/domain/advice/Advice.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/advice/Advice.java
@@ -11,5 +11,8 @@ public class Advice {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
-    String content;
+    String kind_advice;
+
+    String spicy_advice;
+
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/Diary.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/Diary.java
@@ -23,30 +23,23 @@ public class Diary extends BaseTimeEntity {
     private LocalDateTime writedAt;   //이거 중복가능성이 좀 보인다.. BaseTimeEntitiy와 ai서버를 위해서 만든 필드
 
     @Enumerated(EnumType.STRING)
-    private Feeling firstFeeling;
-
-    @Enumerated(EnumType.STRING)
-    private Feeling secondFeeling;
+    private Feeling feeling;
 
 
     @Column(nullable = false,length = 1000)
     private String content;
 
-    String title;
-
-
-    @Enumerated(EnumType.STRING)
-    private List<Feeling> summary;
-
-
+    private String title;
 
     @OneToOne
-    @JoinColumn(name = "kind_advice_id")
-    private Advice kindAdvice;
+    @JoinColumn(name = "advice_id")
+    private Advice advice;
 
-    @OneToOne
-    @JoinColumn(name = "spicy_advice_id")
-    private Advice spicyAdvice;
+
+
+
+
+
 
 
 

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/Diary.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/Diary.java
@@ -16,6 +16,10 @@ public class Diary extends BaseTimeEntity {
     @Column(name = "diary_id")
     private Long id;
 
+    @OneToOne
+    @JoinColumn(name = "advice_id")
+    private Advice advice;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -31,9 +35,7 @@ public class Diary extends BaseTimeEntity {
 
     private String title;
 
-    @OneToOne
-    @JoinColumn(name = "advice_id")
-    private Advice advice;
+
 
 
 

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/Feeling.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/Feeling.java
@@ -5,7 +5,7 @@ public enum Feeling {
     SAD,
     ANGRY,
 
-    WORRYIED,
+    WORRIED,
 
     RELAX,
 

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/Feeling.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/Feeling.java
@@ -5,7 +5,11 @@ public enum Feeling {
     SAD,
     ANGRY,
 
-    WORRY,
+    WORRYIED,
 
-    SURPRISED
+    RELAX,
+
+    SURPRISED,
+
+    NONE
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/member/Member.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/member/Member.java
@@ -2,6 +2,7 @@ package org.kau.kkoolbeeServer.domain.member;
 
 import jakarta.persistence.*;
 import org.kau.kkoolbeeServer.domain.diary.Diary;
+import org.kau.kkoolbeeServer.domain.summary.Summary;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +24,9 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     private UserDiaryType userDiaryType;
+
+    @OneToMany(mappedBy = "member") // Summary에 대한 참조 추가
+    private List<Summary> summaries = new ArrayList<>();
 
 
 

--- a/src/main/java/org/kau/kkoolbeeServer/domain/summary/Summary.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/summary/Summary.java
@@ -1,0 +1,25 @@
+package org.kau.kkoolbeeServer.domain.summary;
+
+import jakarta.persistence.*;
+import org.kau.kkoolbeeServer.domain.member.Member;
+
+@Entity
+public class Summary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    String first_feeling;
+
+    String second_feeling;
+
+    @ManyToOne // 다대일 관계 설정
+    @JoinColumn(name = "member_id") // 외래 키로 사용될 컬럼 지정
+    private Member member;
+
+
+
+
+
+}


### PR DESCRIPTION
## Related Issue 🍫

- close : #[22]

## Summary 🍪

- 내가 뭘했는지
- summary 엔티티 따로 생성 후 member와 다대일 관계생성 (연관관계의 주인 : summary)
- diary엔티티에 기존 advice(kind, spicy), summary 있던거 삭제하고  그냥 advice 추가(일대일관계)
- feeling 클래스에 감정 추가 (NONE,WORRIED,RELAX)
- Member엔티티는 여러개의 summary를 가질 수 있으므로 List<summary> summaries필드 추가 ( 양방향 일대다관계)

## Before i request PR review 🍰

- 코드리뷰로 확인 부탁하는 사항
음 .. summary와 member의 관계만 조금 봐주시면 좋겠어요!!!  어제 말씀해주신대로 member와 summary의 연관관계를 생성했습니다!(양방향 일대다 관계) (멤버하나당 summary들이 있으니) 
