### PR TITLE
Feat/#34 choose diarytype api

### DIFF
--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
@@ -147,4 +147,5 @@ public class DiaryController {
 
 
 
+
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/controller/DiaryController.java
@@ -12,6 +12,9 @@ import org.kau.kkoolbeeServer.domain.diary.dto.response.DiaryContentResponseDto;
 import org.kau.kkoolbeeServer.domain.diary.dto.response.FeelingListResponseDto;
 import org.kau.kkoolbeeServer.domain.diary.dto.response.SlowTypeCreateResponseDto;
 import org.kau.kkoolbeeServer.domain.diary.service.DiaryService;
+import org.kau.kkoolbeeServer.domain.member.Member;
+import org.kau.kkoolbeeServer.domain.member.service.MemberService;
+import org.kau.kkoolbeeServer.global.auth.jwt.JwtProvider;
 import org.kau.kkoolbeeServer.global.common.dto.ApiResponse;
 import org.kau.kkoolbeeServer.global.common.dto.enums.ErrorType;
 import org.kau.kkoolbeeServer.global.common.dto.enums.SuccessType;
@@ -27,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -39,10 +43,12 @@ public class DiaryController {
 
     private DiaryService diaryService;
     private final S3UploaderService s3UploaderService;
+    private MemberService memberService;
     @Autowired
-    public DiaryController(DiaryService diaryService,S3UploaderService s3UploaderService) {
+    public DiaryController(DiaryService diaryService,S3UploaderService s3UploaderService,MemberService memberService) {
         this.diaryService = diaryService;
         this.s3UploaderService=s3UploaderService;
+        this.memberService=memberService;
 
     }
 
@@ -64,7 +70,6 @@ public class DiaryController {
                 );
 
 
-
                 DiaryContentResponseDto responseDto = new DiaryContentResponseDto(
                         diary.getContent(),
                         adviceResponseDto,
@@ -81,12 +86,32 @@ public class DiaryController {
             }
 
     }
-    @PostMapping("/api/diary/list/calendar")
+   /* @PostMapping("/api/diary/list/calendar")
     public ResponseEntity<ApiResponse<?>> getDiariesByMonth(@RequestBody CurrentDateRequestDto requestDto){
         LocalDateTime currentDate = requestDto.getCurrentDate();
 
-            List<Diary>diaries=diaryService.findDiariesByMonth(currentDate);
-            if(diaries.isEmpty()){
+
+        List<Diary>diaries=diaryService.findDiariesByMonth(currentDate);
+        if(diaries.isEmpty()){
+            return ResponseEntity.status(ErrorType.REQUEST_VALIDATION_ERROR.getHttpStatus())
+                    .body(ApiResponse.error(ErrorType.REQUEST_VALIDATION_ERROR, "해당 월에 대한 일기가 존재하지 않습니다."));
+        }
+
+        List<CalenderDiaryResponseDto> diaryDtos=diaries.stream()
+                .map(diary -> new CalenderDiaryResponseDto(diary.getId(), diary.getTitle(), diary.getWritedAt()))
+                .collect(Collectors.toList());
+
+        Map<String,List<CalenderDiaryResponseDto>> responseMap= Map.of("monthList",diaryDtos);
+        return ResponseEntity.ok().body(ApiResponse.success(SuccessType.PROCESS_SUCCESSED, responseMap));*/
+
+    @PostMapping("/api/diary/list/calendar")
+    public ResponseEntity<ApiResponse<?>> getDiariesByMonth(Principal principal,@RequestBody CurrentDateRequestDto requestDto){
+        Long memberId= JwtProvider.getUserFromPrincipal(principal);
+        LocalDateTime currentDate = requestDto.getCurrentDate();
+
+        List<Diary> diaries = diaryService.findDiariesByMonthAndMemberId(currentDate, memberId);
+
+        if(diaries.isEmpty()){
                 return ResponseEntity.status(ErrorType.REQUEST_VALIDATION_ERROR.getHttpStatus())
                         .body(ApiResponse.error(ErrorType.REQUEST_VALIDATION_ERROR, "해당 월에 대한 일기가 존재하지 않습니다."));
             }
@@ -103,8 +128,8 @@ public class DiaryController {
 
     }
 
-    @PostMapping("/api/diary/list/feeling")
-    public ResponseEntity<ApiResponse<?>> getDiariesByFeeling(@RequestBody FeelingListRequestDto requestDto) {
+    /*@PostMapping("/api/diary/list/feeling")
+    public ResponseEntity<ApiResponse<?>> getDiariesByFeeling( @RequestBody FeelingListRequestDto requestDto) {
 
 
             List<Diary> diaries = diaryService.findDiariesByFeeling(requestDto.getFeeling());
@@ -121,9 +146,29 @@ public class DiaryController {
             Map<String, List<FeelingListResponseDto>> responseMap = Map.of("feelingList", feelingList);
             return ResponseEntity.ok().body(ApiResponse.success(SuccessType.PROCESS_SUCCESSED, responseMap));
 
+    }*/
+
+    @PostMapping("/api/diary/list/feeling")
+    public ResponseEntity<ApiResponse<?>> getDiariesByFeeling( Principal principal,@RequestBody FeelingListRequestDto requestDto) {
+
+        Long memberId=JwtProvider.getUserFromPrincipal(principal);
+        List<Diary> diaries = diaryService.findDiariesByMemberIdAndFeeling(memberId,requestDto.getFeeling());
+
+        if (diaries.isEmpty()) {
+            return ResponseEntity.status(ErrorType.REQUEST_VALIDATION_ERROR.getHttpStatus())
+                    .body(ApiResponse.error(ErrorType.REQUEST_VALIDATION_ERROR, "해당 감정에 대한 일기가 존재하지 않습니다."));
+        }
+
+        List<FeelingListResponseDto> feelingList = diaries.stream()
+                .map(diary -> new FeelingListResponseDto(diary.getId(), diary.getWritedAt(), diary.getTitle()))
+                .collect(Collectors.toList());
+
+        Map<String, List<FeelingListResponseDto>> responseMap = Map.of("feelingList", feelingList);
+        return ResponseEntity.ok().body(ApiResponse.success(SuccessType.PROCESS_SUCCESSED, responseMap));
+
     }
 
-    @PostMapping("/api/diary/create/slow")
+   /* @PostMapping("/api/diary/create/slow")
     public ResponseEntity<ApiResponse<?>> createSlowTypeDiary(@RequestPart("imageurl")MultipartFile image,
                                                               @RequestPart("diaryTitle") String diaryTitle,
                                                               @RequestPart("diaryContent") String diaryContent){
@@ -132,6 +177,30 @@ public class DiaryController {
             String imageUrl = s3UploaderService.upload(image);
             Diary diary = new Diary();
             diary.setTitle(diaryTitle);
+            diary.setContent(diaryContent);
+            diary.setImageurl(imageUrl);
+
+            Diary savedDiary=diaryService.saveDiary(diary);
+            SlowTypeCreateResponseDto responseDto=new SlowTypeCreateResponseDto(diary.getId(),diary.getContent(),diary.getTitle(),diary.getImageurl());
+
+            return ResponseEntity.ok().body(ApiResponse.success(SuccessType.PROCESS_SUCCESSED,responseDto));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.error(ErrorType.INTERNAL_SERVER_ERROR,"서버 내부 오류"));
+        }
+    }
+*/
+    @PostMapping("/api/diary/create/slow")
+    public ResponseEntity<ApiResponse<?>> createSlowTypeDiary(Principal principal,@RequestPart("imageurl")MultipartFile image,
+                                                              @RequestPart("diaryTitle") String diaryTitle,
+                                                              @RequestPart("diaryContent") String diaryContent){
+
+        try {
+            String imageUrl = s3UploaderService.upload(image);
+            Long memberId=JwtProvider.getUserFromPrincipal(principal);
+            Member member= memberService.findByIdOrThrow(memberId);
+            Diary diary = new Diary();
+            diary.setTitle(diaryTitle);
+            diary.setMember(member);
             diary.setContent(diaryContent);
             diary.setImageurl(imageUrl);
 

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/repository/DiaryRepository.java
@@ -11,8 +11,11 @@ import java.util.List;
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary,Long> {
 
-    List<Diary> findByWritedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);
+    /*List<Diary> findByWritedAtBetween(LocalDateTime startDateTime, LocalDateTime endDateTime);*/
+    List<Diary> findByMemberIdAndWritedAtBetween(Long memberId, LocalDateTime startDate, LocalDateTime endDate);
 
-    List<Diary> findByFeeling(Feeling feeling);
+    /*List<Diary> findByFeeling(Feeling feeling);*/
+
+    List<Diary> findByMemberIdAndFeeling(Long memberId,Feeling feeling);
 
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/diary/service/DiaryService.java
@@ -5,6 +5,7 @@ import org.kau.kkoolbeeServer.domain.diary.Feeling;
 import org.kau.kkoolbeeServer.domain.diary.repository.DiaryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.swing.text.html.Option;
 import java.time.LocalDateTime;
@@ -27,16 +28,28 @@ public class DiaryService {
 
 
     }
-    public List<Diary> findDiariesByMonth(LocalDateTime date) {
+   /* public List<Diary> findDiariesByMonth(LocalDateTime date) {
         LocalDateTime startOfMonth = date.withDayOfMonth(1).toLocalDate().atStartOfDay();
         LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusSeconds(1);
         return diaryRepository.findByWritedAtBetween(startOfMonth, endOfMonth);
+    }*/
+
+    public List<Diary> findDiariesByMonthAndMemberId(LocalDateTime date, Long memberId) {
+        LocalDateTime startOfMonth = date.withDayOfMonth(1).toLocalDate().atStartOfDay();
+        LocalDateTime endOfMonth = startOfMonth.plusMonths(1).minusSeconds(1);
+        return diaryRepository.findByMemberIdAndWritedAtBetween(memberId, startOfMonth, endOfMonth);
     }
 
-    public List<Diary> findDiariesByFeeling(String feeling) {
+
+
+   /* public List<Diary> findDiariesByFeeling(String feeling) {
         return diaryRepository.findByFeeling(Feeling.valueOf(feeling));
     }
-
+*/
+    public List<Diary> findDiariesByMemberIdAndFeeling(Long memberId,String feeling) {
+        return diaryRepository.findByMemberIdAndFeeling(memberId,Feeling.valueOf(feeling));
+    }
+    @Transactional
     public Diary saveDiary(Diary diary){
         return diaryRepository.save(diary);
     }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/member/Member.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/member/Member.java
@@ -54,4 +54,9 @@ public class Member {
     public static Member of(String kakaoId) {
         return new Member(kakaoId);
     }
+
+
+    public void setDiaryType(UserDiaryType userDiaryType) {
+        this.userDiaryType = userDiaryType;
+    }
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/member/controller/MemberController.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/member/controller/MemberController.java
@@ -40,7 +40,7 @@ public class MemberController {
     @PatchMapping("/log-out") // Spring Security 자체의 logout과 겹치지 않기 위해 이렇게 설정
     public ResponseEntity<ApiResponse<?>> logout(Principal principal) {
 
-        memberService.logout(JwtProvider.getUserFromPrincial(principal));
+        memberService.logout(JwtProvider.getUserFromPrincipal(principal));
         return ResponseEntity.ok(ApiResponse.success(SuccessType.LOGOUT_SUCCESS));
     }
 
@@ -50,34 +50,18 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponse.success(SuccessType.KAKAO_ACCESS_TOKEN_SUCCESS, kakaoLoginService.getKakaoAccessToken(code)));
     }
 
-    /*@PostMapping("/member/character")
-    public ResponseEntity<ApiResponse<?>> diaryType(
-            @RequestHeader("Authorization")String token,@RequestBody String userDiaryType){
+    @PostMapping("/member/character")
+    public ResponseEntity<ApiResponse<?>> diaryType(Principal principal,@RequestBody String userDiaryType){
 
-        Long memberId=jwtProvider.getUserFromJwt(token);
-        UserDiaryType DiaryType=UserDiaryType.valueOf(userDiaryType);
-        memberService.setUserDiaryType(memberId,DiaryType);
+        Long memberId=JwtProvider.getUserFromPrincipal(principal);
 
-        return ResponseEntity.ok(ApiResponse.success(SuccessType.PROCESS_SUCCESSED));
-
-
-    }
-*/
-   /* @PostMapping("/member/character")
-    public ResponseEntity<ApiResponse<?>> diaryType(
-            @RequestHeader("Authorization")String token,@RequestBody String userDiaryType){
-
-        memberService.setUserDiaryType(token,userDiaryType);
+        UserDiaryType diaryType=UserDiaryType.valueOf(userDiaryType);
+        memberService.setUserDiaryType(memberId,diaryType);
 
         return ResponseEntity.ok(ApiResponse.success(SuccessType.PROCESS_SUCCESSED));
 
 
     }
-
-
-    @GetMapping("/member/member")
-    public ResponseEntity<ApiResponse<?>> diarry(Principal principal)
-*/
 
 
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/member/controller/MemberController.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package org.kau.kkoolbeeServer.domain.member.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.kau.kkoolbeeServer.domain.member.UserDiaryType;
 import org.kau.kkoolbeeServer.domain.member.dto.response.MemberLoginResponseDto;
 import org.kau.kkoolbeeServer.domain.member.service.MemberService;
 import org.kau.kkoolbeeServer.global.auth.fegin.kakao.KakaoLoginService;
@@ -20,6 +21,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final KakaoLoginService kakaoLoginService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<MemberLoginResponseDto>> login(
@@ -47,4 +49,35 @@ public class MemberController {
         @RequestHeader("Authorization") String code) {
         return ResponseEntity.ok(ApiResponse.success(SuccessType.KAKAO_ACCESS_TOKEN_SUCCESS, kakaoLoginService.getKakaoAccessToken(code)));
     }
+
+    /*@PostMapping("/member/character")
+    public ResponseEntity<ApiResponse<?>> diaryType(
+            @RequestHeader("Authorization")String token,@RequestBody String userDiaryType){
+
+        Long memberId=jwtProvider.getUserFromJwt(token);
+        UserDiaryType DiaryType=UserDiaryType.valueOf(userDiaryType);
+        memberService.setUserDiaryType(memberId,DiaryType);
+
+        return ResponseEntity.ok(ApiResponse.success(SuccessType.PROCESS_SUCCESSED));
+
+
+    }
+*/
+   /* @PostMapping("/member/character")
+    public ResponseEntity<ApiResponse<?>> diaryType(
+            @RequestHeader("Authorization")String token,@RequestBody String userDiaryType){
+
+        memberService.setUserDiaryType(token,userDiaryType);
+
+        return ResponseEntity.ok(ApiResponse.success(SuccessType.PROCESS_SUCCESSED));
+
+
+    }
+
+
+    @GetMapping("/member/member")
+    public ResponseEntity<ApiResponse<?>> diarry(Principal principal)
+*/
+
+
 }

--- a/src/main/java/org/kau/kkoolbeeServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/member/service/MemberService.java
@@ -92,13 +92,21 @@ public class MemberService {
         return memberRepository.existsByKakaoId(kakaoId);
     }
 
-   /* @Transactional
+    @Transactional
     public void setUserDiaryType(Long memberId, UserDiaryType userDiaryType){
+
         Member member=memberRepository.findByIdOrThrow(memberId);
         member.setDiaryType(userDiaryType);
         memberRepository.save(member);
 
-    }*/
+    }
+
+    @Transactional(readOnly = true)
+    public Member findByIdOrThrow(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER_ERROR));
+    }
+
 
   /*  @Transactional
     public void setUserDiaryType(String Token, String userDiaryType){

--- a/src/main/java/org/kau/kkoolbeeServer/domain/member/service/MemberService.java
+++ b/src/main/java/org/kau/kkoolbeeServer/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package org.kau.kkoolbeeServer.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.kau.kkoolbeeServer.domain.member.Member;
+import org.kau.kkoolbeeServer.domain.member.UserDiaryType;
 import org.kau.kkoolbeeServer.domain.member.dto.response.MemberLoginResponseDto;
 import org.kau.kkoolbeeServer.domain.member.repository.MemberRepository;
 import org.kau.kkoolbeeServer.global.auth.fegin.kakao.KakaoLoginService;
@@ -90,4 +91,25 @@ public class MemberService {
     private boolean isUserByKakaoId(String kakaoId) {
         return memberRepository.existsByKakaoId(kakaoId);
     }
+
+   /* @Transactional
+    public void setUserDiaryType(Long memberId, UserDiaryType userDiaryType){
+        Member member=memberRepository.findByIdOrThrow(memberId);
+        member.setDiaryType(userDiaryType);
+        memberRepository.save(member);
+
+    }*/
+
+  /*  @Transactional
+    public void setUserDiaryType(String Token, String userDiaryType){
+
+        Token=parseTokenString(Token);
+        UserDiaryType DiaryType=UserDiaryType.valueOf(userDiaryType);
+
+        jwtProvider.getUserFromJwt()
+
+
+
+
+    }*/
 }

--- a/src/main/java/org/kau/kkoolbeeServer/global/auth/jwt/JwtProvider.java
+++ b/src/main/java/org/kau/kkoolbeeServer/global/auth/jwt/JwtProvider.java
@@ -155,7 +155,7 @@ public class JwtProvider {
         return Keys.hmacShaKeyFor(encodedKey.getBytes());
     }
 
-    public static Long getUserFromPrincial(Principal principal) {
+    public static Long getUserFromPrincipal(Principal principal) {
         if (isNull(principal)) {
             throw new CustomException(EMPTY_PRINCIPLE_ERROR);
         }


### PR DESCRIPTION
## Related Issue 🍫

- close : #[34]

## Summary 🍪

- Principal 객체로 accessToken값에서 memberId를 뽑아와서
   memberId바탕으로 그 멤버의 diaryType정하는api 구현 
기존 api들 전부 memberId받아서 그 멤버에 해당하는 다이어리들만 적용되게
수정 

## Before i request PR review 🍰

- 코드리뷰로 확인 부탁하는 사항
전부다 로직은 같게했어요  Princpai에서 memberId뽑아오는 걸로!!! ( Principal이 MemberEntity의 id값을 반환한다는 가정하에))
